### PR TITLE
added some space between TitleText and SubtitleText

### DIFF
--- a/app/src/main/java/com/github/pavlospt/CircleView.java
+++ b/app/src/main/java/com/github/pavlospt/CircleView.java
@@ -198,7 +198,7 @@ public class CircleView extends View {
                     yPos,
                     mTitleTextPaint);
         }
-
+        // draw SubTitle text
         if (mShowSubtitle) {
             canvas.drawText(mSubtitleText,
                     xPos,


### PR DESCRIPTION

Prior  to this change, the margin between the TitleText and the SubtitleText was hard coded which caused the two test drawings to overlap in some cases, I have implemented a way the margin margin is automatically calculated based on the height of the TitleText.


**Before..**
![img_20150905_175038](https://cloud.githubusercontent.com/assets/6098606/9701494/10b38e1e-53fa-11e5-98f4-a93a169655f9.JPG)





**After..**
![img_20150905_174949](https://cloud.githubusercontent.com/assets/6098606/9701501/389867d8-53fa-11e5-9ceb-59f122ee2736.JPG)
